### PR TITLE
`Fix` Delete expired OTTs + Encode tokens on URLs

### DIFF
--- a/apps/server/src/controllers/account/deleteHandler.ts
+++ b/apps/server/src/controllers/account/deleteHandler.ts
@@ -5,6 +5,7 @@ import { queryUserById } from "../../services/account.services";
 import { deleteUser } from "../../services/auth.services";
 import {
     createOneTimeToken,
+    deleteUserExpiredTokensByUserId,
     getUserOneTimeTokens,
     queryOneTimeToken,
 } from "../../services/tokens.services";
@@ -19,6 +20,7 @@ export async function requestAccountDeletionHandler({
     request: FastifyRequest;
     response: FastifyReply;
 }) {
+    await deleteUserExpiredTokensByUserId(userId);
     const oneTimeTokens = await getUserOneTimeTokens(userId);
 
     for (const token of oneTimeTokens) {
@@ -56,7 +58,7 @@ export async function requestAccountDeletionHandler({
         tokenType: "account_deletion",
     });
 
-    const verificationUrl = `${request.protocol}://${request.host}/account/confirm-deletion?token=${oneTimeToken.token}`;
+    const verificationUrl = `${request.protocol}://${request.host}/account/confirm-deletion?token=${encodeURIComponent(oneTimeToken.token)}`;
 
     await sendAccountDeletionEmail({
         to: user.email,

--- a/apps/server/src/controllers/auth/registerHandler.ts
+++ b/apps/server/src/controllers/auth/registerHandler.ts
@@ -52,7 +52,7 @@ export async function registerHandler({
 
     const redirectUrl = `${env.FRONTEND_URL}/auth/login`;
 
-    const verificationUrl = `${request.protocol}://${request.host}/auth/verify?token=${oneTimeToken.token}&redirectUrl=${encodeURIComponent(redirectUrl)}`;
+    const verificationUrl = `${request.protocol}://${request.host}/auth/verify?token=${encodeURIComponent(oneTimeToken.token)}&redirectUrl=${encodeURIComponent(redirectUrl)}`;
 
     const verificationEmail = await sendAccountVerificationEmail({
         to: newUser.email,

--- a/apps/server/src/controllers/credentials/passwordResetHandler.ts
+++ b/apps/server/src/controllers/credentials/passwordResetHandler.ts
@@ -1,17 +1,13 @@
-import { validatePasswordResetTokenSchema } from "./../../docs/credentials.docs";
 import { env } from "@/src/env";
 import { hashPassword } from "@/src/helpers/hash-password";
-import {
-    sendAccountDeletionEmail,
-    emailDisplayName,
-    sendPasswordResetEmail,
-} from "@/src/helpers/mailing";
+import { emailDisplayName, sendPasswordResetEmail } from "@/src/helpers/mailing";
 import { apiResponse } from "@/src/helpers/response";
 import { queryUserByEmail } from "@/src/services/auth.services";
 import { updateUserPassword } from "@/src/services/credentials.services";
 import {
     createOneTimeToken,
     deleteOneTimeToken,
+    deleteUserExpiredTokensByEmail,
     getUserOneTimeTokensWithEmail,
     queryOneTimeToken,
 } from "@/src/services/tokens.services";
@@ -26,6 +22,7 @@ export async function requestPasswordResetHandler({
     email: string;
     response: FastifyReply;
 }) {
+    await deleteUserExpiredTokensByEmail(email);
     const oneTimeTokens = await getUserOneTimeTokensWithEmail(email);
 
     for (const token of oneTimeTokens) {

--- a/apps/server/src/routes/account.routes.ts
+++ b/apps/server/src/routes/account.routes.ts
@@ -49,8 +49,9 @@ export async function accountRoutes(fastify: FastifyTypedInstance) {
         { schema: accountDocs.confirmDeletionSchema },
         async (request: FastifyRequest<{ Querystring: { token: string } }>, response) => {
             const query = await confirmAccountDeletionSchema.parseAsync(request.query);
+            const token = decodeURIComponent(query.token);
 
-            await confirmAccountDeletionHandler({ token: query.token, response });
+            await confirmAccountDeletionHandler({ token, response });
         }
     );
 }

--- a/apps/server/src/routes/auth.routes.ts
+++ b/apps/server/src/routes/auth.routes.ts
@@ -35,9 +35,9 @@ export async function authRoutes(fastify: FastifyTypedInstance) {
             response
         ) => {
             const query = await verifyEmailSchema.parseAsync(request.query);
+            const token = decodeURIComponent(query.token);
 
-            console.log(query.token);
-            await verifyHandler({ token: query.token, redirectUrl: query.redirectUrl, response });
+            await verifyHandler({ token, redirectUrl: query.redirectUrl, response });
         }
     );
 

--- a/apps/server/src/routes/credentials.routes.ts
+++ b/apps/server/src/routes/credentials.routes.ts
@@ -51,7 +51,9 @@ export async function credentialsRoutes(fastify: FastifyTypedInstance) {
         { schema: credentialDocs.validatePasswordResetTokenSchema },
         async (request: FastifyRequest<{ Querystring: { token: string } }>, response) => {
             const query = await z.object({ token: z.string() }).parseAsync(request.query);
-            await validatePasswordResetTokenHandler({ token: query.token, response });
+            const token = decodeURIComponent(query.token);
+
+            await validatePasswordResetTokenHandler({ token, response });
         }
     );
 }

--- a/apps/server/src/services/tokens.services.ts
+++ b/apps/server/src/services/tokens.services.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq, gte, sql } from "drizzle-orm";
 import { FastifyReply } from "fastify";
 
 import { db } from "../db/connection";
@@ -110,6 +110,18 @@ export async function queryOneTimeToken(token: string) {
 
 export async function deleteOneTimeToken(token: string) {
     return await db.delete(oneTimeTokens).where(eq(oneTimeTokens.token, token));
+}
+
+export async function deleteUserExpiredTokensByUserId(userId: string) {
+    return await db
+        .delete(oneTimeTokens)
+        .where(and(eq(oneTimeTokens.userId, userId), gte(sql`NOW()`, oneTimeTokens.expiresAt)));
+}
+
+export async function deleteUserExpiredTokensByEmail(email: string) {
+    return await db
+        .delete(oneTimeTokens)
+        .where(and(eq(oneTimeTokens.relatesTo, email), gte(sql`NOW()`, oneTimeTokens.expiresAt)));
 }
 
 export async function getUserOneTimeTokens(userId: string) {


### PR DESCRIPTION
- Expired `OneTimeTokens` were not deleted at any point, meaning that if the user tried to request a new password reset after waiting for the expiration of an unfinished one (30 minutes), it would conflict with the one that was not deleted after expiraton. Now we delete all the expired tokens for an user on endpoints that checks for existing ones.

- Encoded `OneTimeTokens` when they were passed to URL query strings to prevent characters like the slash '/' to mess with the routing.