### PR TITLE
`Fix` Allow multiple sessions per user.

### DIFF
--- a/apps/server/src/controllers/auth/revalidateHandler.ts
+++ b/apps/server/src/controllers/auth/revalidateHandler.ts
@@ -5,7 +5,7 @@ import { apiResponse } from "@/src/helpers/response";
 import { signJWT } from "../../helpers/jwt";
 import { generateRefreshToken } from "../../helpers/tokens";
 import { queryTokenData } from "../../services/auth.services";
-import { setJWTCookie, setRefreshToken } from "../../services/tokens.services";
+import { deleteRefreshToken, setJWTCookie, setRefreshToken } from "../../services/tokens.services";
 
 /*
 This function is used to revalidate the JWT token
@@ -72,6 +72,11 @@ export async function revalidateHandler({
             })
         );
     }
+
+    /**
+     * If all checks succeed, delete the used refreshToken, issue a new JWT and a new refreshToken
+     */
+    await deleteRefreshToken(tokenData.token);
 
     const jwt = signJWT({
         payload: {

--- a/apps/server/src/docs/auth.docs.ts
+++ b/apps/server/src/docs/auth.docs.ts
@@ -84,7 +84,9 @@ const revalidateSchema: FastifySchema = {
         
 Needs a \`refreshToken\` cookie, received from \`/auth/login\`, to succeed.
 
-This should be used when the short lived \`JWT\` expires.        
+This should be used when the short lived \`JWT\` expires.
+
+Will invalidate the passed \`refreshToken\` if all checks succeed and return a new one.        
         `,
     summary: "Revalidate JWT",
     response: {


### PR DESCRIPTION
- The login was invalidating all the refreshTokens the user had issued on his account, meaning that if he logged in on another device, the first one would be signed out.
- Fixed by deleting only the expired ones.